### PR TITLE
Update load.py

### DIFF
--- a/load.py
+++ b/load.py
@@ -316,8 +316,9 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
                                 for z in range(0, len(this.TodayData[y][0]['Factions'])):
                                     if this.TodayData[y][0]['Factions'][z]['Faction'] == fe3:
                                         if (this.TodayData[y][0]['Factions'][z]['FactionState'] == 'Election' and entry['Name'] in this.MissionListElection) \
-                                        or (this.TodayData[y][0]['Factions'][z]['FactionState'] in this.ConflictStates and entry['Name'] in this.MissionListConflict):
-                                            this.TodayData[y][0]['Factions'][z]['MissionPoints'] += 1
+                                        or (this.TodayData[y][0]['Factions'][z]['FactionState'] in this.ConflictStates and entry['Name'] in this.MissionListConflict) \
+                                            and this.MissionLog[p]["Faction"] == fe3:
+                                                this.TodayData[y][0]['Factions'][z]['MissionPoints'] += 1
         for count in range(len(this.MissionLog)):
             if this.MissionLog[count]["MissionID"] == entry["MissionID"]:
                 this.MissionLog.pop(count)


### PR DESCRIPTION
Add check on non-election Conflict type mission completion to only award a MissionPoints to the mission giver instead of both sides (as the MissionCompleted event of a massacre mission for civil war/war conflicts has both factions mentioned in the FactionEffects, so for both fe3 in fe a tally would be added otherwise).