### PR TITLE
strip the url of leading/trailing whitespaces

### DIFF
--- a/bgstally/discord.py
+++ b/bgstally/discord.py
@@ -159,11 +159,11 @@ class Discord:
         """
         match channel:
             case DiscordChannel.BGS:
-                return self.bgstally.state.DiscordBGSWebhook.get()
+                return self.bgstally.state.DiscordBGSWebhook.get().strip()
             case DiscordChannel.FLEETCARRIER:
-                return self.bgstally.state.DiscordFCJumpWebhook.get()
+                return self.bgstally.state.DiscordFCJumpWebhook.get().strip()
             case DiscordChannel.THARGOIDWAR:
-                return self.bgstally.state.DiscordTWWebhook.get()
+                return self.bgstally.state.DiscordTWWebhook.get().strip()
 
 
     def _is_webhook_valid(self, webhook:str):


### PR DESCRIPTION
Users can accidentally paste in a leading/trailing whitespace. This helps fix that without requiring EDMC to change behavior.