### PR TITLE
Fix and comment on the 'Discord activity' component

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ And finally, a huge thank you to:
 * All the translators who have given their time and effort:
     * French - CMDR ThArGos
     * German - CMDR Ryan Murdoc
-    * Italian - CMDR FrostBit aka @GLWine
+    * Italian - CMDR FrostBit / [@GLWine](https://github.com/GLWine)
     * Portuguese (Portugal) - CMDR Holy Nothing
     * Portuguese (Brazil) - CMDR FelaKuti
     * Russian - CMDR KuzSan

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ And finally, a huge thank you to:
 * All the translators who have given their time and effort:
     * French - CMDR ThArGos
     * German - CMDR Ryan Murdoc
-    * Italian - CMDR FrostBit
+    * Italian - CMDR FrostBit aka @GLWine
     * Portuguese (Portugal) - CMDR Holy Nothing
     * Portuguese (Brazil) - CMDR FelaKuti
     * Russian - CMDR KuzSan

--- a/bgstally/windows/activity.py
+++ b/bgstally/windows/activity.py
@@ -75,7 +75,7 @@ class WindowActivity:
                                                                *activity_type_options.values(),
                                                                command=partial(self._activity_type_selected, activity_type_options), direction='above')
         self.mnu_activity_type.pack(side=tk.RIGHT, pady=5)
-        ttk.Label(frm_buttons, text="Activity to post:").pack(side=tk.RIGHT, pady=5)
+        ttk.Label(frm_buttons, text=_("Activity to post:")).pack(side=tk.RIGHT, pady=5) # LANG: Label on activity window
 
         frm_discord = ttk.Frame(ContainerFrame)
         frm_discord.pack(fill=tk.X, side=tk.BOTTOM, padx=5, pady=5)


### PR DESCRIPTION
Added the _() indicator to the "Activity to post" text to attach the translation, added a comment for the translation