### PR TITLE
Replacement of the symbol ❓ with ⓘ

### DIFF
--- a/bgstally/windows/activity.py
+++ b/bgstally/windows/activity.py
@@ -82,7 +82,7 @@ class WindowActivity:
         frm_discord.pack(fill=tk.X, side=tk.BOTTOM, padx=5, pady=5)
         frm_discord.columnconfigure(0, weight=2)
         frm_discord.columnconfigure(1, weight=1)
-        lbl_discord_report:ttk.Label = ttk.Label(frm_discord, text=_("❓ Discord Report Preview"), font=FONT_HEADING_2, cursor="hand2") # LANG: Label on activity window
+        lbl_discord_report:ttk.Label = ttk.Label(frm_discord, text=_("Discord Report Preview ⓘ"), font=FONT_HEADING_2, cursor="hand2") # LANG: Label on activity window
         lbl_discord_report.grid(row=0, column=0, sticky=tk.W)
         lbl_discord_report.bind("<Button-1>", self._show_legend_window)
         ToolTip(lbl_discord_report, text=_("Show legend window")) # LANG: Activity window tooltip


### PR DESCRIPTION
Changing the text `❓ Discord Report Preview` to `Discord Report Preview ⓘ` (line 85). 
The aim is to make it more understandable that if clicked it shows a ToolTip with the legend of the symbols that can be emitted in Discord messages.

Changing the text will require a revision of the translations.

Before and after the change:
![image](https://github.com/aussig/BGS-Tally/assets/54741923/73ddccaa-b51f-4fb9-9c61-5c64cd73f6cb)
![image](https://github.com/aussig/BGS-Tally/assets/54741923/3b3fe989-1002-4a24-b1a8-3329c2d5e805)
