### PR TITLE
Fix regex pattern with raw string literals

### DIFF
--- a/bgstally/utils.py
+++ b/bgstally/utils.py
@@ -153,5 +153,5 @@ def string_to_alphanumeric(s: str) -> str:
     Returns:
         str: The cleaned string
     """
-    pattern: re.Pattern = re.compile('[\W_]+')
+    pattern: re.Pattern = re.compile(r'[\W_]+')
     return pattern.sub('', s)

--- a/bgstally/widgets.py
+++ b/bgstally/widgets.py
@@ -60,8 +60,8 @@ class DiscordAnsiColorText(tk.Text):
 
     # define some regexes which will come in handy in filtering
     # out the ansi color codes
-    color_pat = re.compile("\x01?\x1b(\[[\d;]*m?)\x02?")
-    inner_color_pat = re.compile("^\[([\d;]*)m$")
+    color_pat = re.compile(r'\x01?\x1b(\[[\d;]*m?)\x02?')
+    inner_color_pat = re.compile(r'^\[([\d;]*)m$')
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
### What does this PR do?

- Updates regular expressions in `DiscordAnsiColorText` and `string_to_alphanumeric` to use raw string literals.
- This ensures correct handling of escape sequences in regular expressions.

### Why is this important?

- The previous regex syntax could have led to misinterpretations of escape sequences, causing errors in string processing and filtering.
- By switching to raw string literals, we prevent potential bugs and improve the readability and maintainability of the code.

### Effects of not applying this change:

- If left unchanged, the regular expressions could fail to properly process special characters, leading to incorrect results in the application, such as improperly filtered ANSI color codes or failure to correctly remove non-alphanumeric characters.
