### PR TITLE
Fix padding issue in Tkinter grid by using a tuple

### DIFF
--- a/bgstally/windows/cmdrs.py
+++ b/bgstally/windows/cmdrs.py
@@ -72,7 +72,7 @@ class WindowCMDRs:
         treeview.pack(fill=tk.BOTH, expand=1)
 
         current_row = 0
-        ttk.Label(frm_details, text=_("CMDR Details"), font=FONT_HEADING_1, foreground=COLOUR_HEADING_1).grid(row=current_row, column=0, sticky=tk.W, columnspan=4, padx=5, pady=[5, 0]); current_row += 1 # LANG: Label on CMDR window
+        ttk.Label(frm_details, text=_("CMDR Details"), font=FONT_HEADING_1, foreground=COLOUR_HEADING_1).grid(row=current_row, column=0, sticky=tk.W, columnspan=4, padx=5, pady=(5, 0)); current_row += 1 # LANG: Label on CMDR window
         ttk.Label(frm_details, text=_("Name: "), font=FONT_HEADING_2).grid(row=current_row, column=0, sticky=tk.W, padx=5) # LANG: Label on CMDR window
         self.lbl_cmdr_details_name: ttk.Label = ttk.Label(frm_details, text="", width=50)
         self.lbl_cmdr_details_name.grid(row=current_row, column=1, sticky=tk.W, padx=5)
@@ -87,7 +87,7 @@ class WindowCMDRs:
         self.lbl_cmdr_details_squadron_inara.grid(row=current_row, column=3, sticky=tk.W, padx=5); current_row += 1
         ttk.Label(frm_details, text=_("Interaction: "), font=FONT_HEADING_2).grid(row=current_row, column=0, sticky=tk.W, padx=5) # LANG: Label on CMDR window
         self.lbl_cmdr_details_interaction: ttk.Label = ttk.Label(frm_details, text="")
-        self.lbl_cmdr_details_interaction.grid(row=current_row, column=1, sticky=tk.W, padx=5, pady=[0, 5]); current_row += 1
+        self.lbl_cmdr_details_interaction.grid(row=current_row, column=1, sticky=tk.W, padx=5, pady=(0, 5)); current_row += 1
 
         for column in column_info:
             treeview.heading(column['title'], text=column['title'].title(), sort_by=column['type'])


### PR DESCRIPTION
### Description:
This PR fixes an issue with the use of the `pady` parameter in Tkinter widgets. Previously, a list (`[5, 0]`) was passed to define the vertical padding, but Tkinter expects a tuple. This change resolves the issue by using a tuple instead of a list, ensuring proper padding handling in the layout.

### Key Changes:
- Changed the `pady` parameter from a list to a tuple, from `[5, 0]` to `(5, 0)`.

### Why this change:
This change is required to ensure compatibility with Tkinter’s API, which expects `pady` (and similar parameters) to be passed as tuples, not lists.

### Testing:
No additional tests are needed as this change only affects the layout handling in the Tkinter GUI.

### References:
- No specific issue, minor change to fix layout behavior.