### PR TITLE
Add new commodities from trailblazers and previous updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@
 * The individual tick time for each system is now reported on the activity window and on the overlay in-game.
 * You can now customise the Discord avatar image for your Discord posts, if you want to override the default BGS-Tally icon.
 
+
 ### Bug Fixes:
 
 * The tick time was not being sent in /event API calls.
 * Any Search and Rescue (e.g. excape pods) would cause the overlay to stop displaying your work in that system.
 * When abandoning of failing a mission that was not logged when it was originally accepted (e.g. when BGS-Tally was not running), and sending events to an API, the API call would fail.
+* Fixed bug which would cause the Fleetcarrier window to fail to load properly if newer Trailblazers or Thargoid war commodities had buy or sell orders set.
+
 
 ### API Changes ([v1.6](https://studio-ws.apicur.io/sharing/xxxxxxxxxxxxxxxxxxxxxxxxxxxx)):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,12 @@
 * The individual tick time for each system is now reported on the activity window and on the overlay in-game.
 * You can now customise the Discord avatar image for your Discord posts, if you want to override the default BGS-Tally icon.
 
-
 ### Bug Fixes:
 
 * The tick time was not being sent in /event API calls.
 * Any Search and Rescue (e.g. excape pods) would cause the overlay to stop displaying your work in that system.
 * When abandoning of failing a mission that was not logged when it was originally accepted (e.g. when BGS-Tally was not running), and sending events to an API, the API call would fail.
 * Fixed bug which would cause the Fleetcarrier window to fail to load properly if newer Trailblazers or Thargoid war commodities had buy or sell orders set.
-
 
 ### API Changes ([v1.6](https://studio-ws.apicur.io/sharing/xxxxxxxxxxxxxxxxxxxxxxxxxxxx)):
 

--- a/bgstally/fleetcarrier.py
+++ b/bgstally/fleetcarrier.py
@@ -11,6 +11,7 @@ from thirdparty.colors import *
 
 FILENAME = "fleetcarrier.json"
 COMMODITIES_CSV_FILENAME = "commodity.csv"
+RARE_COMMODITIES_CSV_FILENAME = "rare_commodity.csv"
 
 
 class FleetCarrier:
@@ -357,6 +358,16 @@ class FleetCarrier:
                     self.commodities[rows.get('symbol', "").lower()] = rows.get('name', "")
         except Exception as e:
                 Debug.logger.error(f"Unable to load {filepath}")
+        
+        rare_filepath:str = path.join(self.bgstally.plugin_dir, FOLDER_DATA, RARE_COMMODITIES_CSV_FILENAME)
+        try:
+            with open(rare_filepath, encoding = 'utf-8') as csv_file_handler:
+                csv_reader = csv.DictReader(csv_file_handler)
+
+                for rows in csv_reader:
+                    self.commodities[rows.get('symbol', "").lower()] = rows.get('name', "")
+        except Exception as e:
+                Debug.logger.error(f"Unable to load {rare_filepath}")
 
 
     def _as_dict(self):

--- a/data/commodity.csv
+++ b/data/commodity.csv
@@ -249,3 +249,9 @@ id,symbol,category,name
 129022407,CoralSap,Salvage,Coral Sap
 129022408,UnknownMineral,Salvage,Impure Spire Mineral
 129022409,UnknownRefinedMineral,Salvage,Semi-Refined Spire Mineral
+129030459,ThargoidTitanDriveComponent,Salvage,Titan Drive Component
+129030460,ThargoidCystSpecimen,Salvage,Cyst Specimen
+129030461,ThargoidBoneFragments,Salvage,Bone Fragments
+129030462,ThargoidOrganSample,Salvage,Organ Sample
+129031238,Steel,Metals,Steel
+129031327,Haematite,Minerals,Haematite

--- a/data/rare_commodity.csv
+++ b/data/rare_commodity.csv
@@ -1,0 +1,143 @@
+id,symbol,market_id,category,name
+128666746,EraninPearlWhisky,128001536,Legal Drugs,Eranin Pearl Whisky
+128666747,LavianBrandy,128106744,Legal Drugs,Lavian Brandy
+128667019,HIP10175BushMeat,3223234816,Foods,HIP 10175 Bush Meat
+128667020,AlbinoQuechuaMammoth,3222822912,Foods,Albino Quechua Mammoth Meat
+128667021,UtgaroarMillenialEggs,128037120,Foods,Utgaroar Millennial Eggs
+128667022,WitchhaulKobeBeef,3223358720,Foods,Witchhaul Kobe Beef
+128667023,KarsukiLocusts,3225028096,Foods,Karsuki Locusts
+128667024,GiantIrukamaSnails,3225345792,Foods,Giant Irukama Snails
+128667025,BaltahSineVacuumKrill,128088056,Foods,Baltah'sine Vacuum Krill
+128667026,CetiRabbits,3222560000,Foods,Ceti Rabbits
+128667027,KachiriginLeaches,3221595648,Medicines,Kachirigin Filter Leeches
+128667028,LyraeWeed,3226417152,Legal Drugs,Lyrae Weed
+128667029,OnionHead,128129272,Legal Drugs,Onionhead
+128667030,TarachTorSpice,128041984,Legal Drugs,Tarach Spice
+128667031,Wolf1301Fesh,128084984,Legal Drugs,Wolf Fesh
+128667032,BorasetaniPathogenetics,3229638400,Weapons,Borasetani Pathogenetics
+128667033,HIP118311Swarm,3223177472,Weapons,HIP 118311 Swarm
+128667034,KonggaAle,3226978048,Legal Drugs,Kongga Ale
+128667035,WuthieloKuFroth,3222155776,Legal Drugs,Wuthielo Ku Froth
+128667036,AlacarakmoSkinArt,3231373824,Consumer Items,Alacarakmo Skin Art
+128667037,EleuThermals,3230624768,Consumer Items,Eleu Thermals
+128667038,EshuUmbrellas,3222295552,Consumer Items,Eshu Umbrellas
+128667039,KaretiiCouture,3227333120,Consumer Items,Karetii Couture
+128667040,NjangariSaddles,3222416896,Consumer Items,Njangari Saddles
+128667041,AnyNaCoffee,3229880064,Foods,Any Na Coffee
+128667042,CD75CatCoffee,3228566016,Foods,CD-75 Kitten Brand Coffee
+128667043,GomanYauponCoffee,3224449792,Foods,Goman Yaupon Coffee
+128667044,VolkhabBeeDrones,3227831808,Machinery,Volkhab Bee Drones
+128667045,KinagoInstruments,3227394304,Consumer Items,Kinago Violins
+128667046,NgunaModernAntiques,3221538304,Consumer Items,Nguna Modern Antiques
+128667047,RajukruStoves,3227512320,Consumer Items,Rajukru Multi-Stoves
+128667048,TiolceWaste2PasteUnits,3224141312,Consumer Items,Tiolce Waste2Paste Units
+128667049,ChiEridaniMarinePaste,128128760,Foods,Chi Eridani Marine Paste
+128667050,EsusekuCaviar,3226919680,Foods,Esuseku Caviar
+128667051,LiveHecateSeaWorms,128042496,Foods,Live Hecate Sea Worms
+128667052,HelvetitjPearls,3231094528,Metals,Helvetitj Pearls
+128667053,HIP41181Squid,3227995392,Foods,HIP Proto-Squid
+128667054,CoquimSpongiformVictuals,3223832576,Foods,Coquim Spongiform Victuals
+128667055,AerialEdenApple,128083448,Foods,Eden Apples of Aerial
+128667056,NeritusBerries,3228206080,Foods,Neritus Berries
+128667057,OchoengChillies,3226719232,Foods,Ochoeng Chillies
+128667058,DeuringasTruffles,3229713408,Foods,Deuringas Truffles
+128667059,HR7221Wheat,3226170880,Foods,HR 7221 Wheat
+128667060,JarouaRice,3224698112,Foods,Jaroua Rice
+128667061,BelalansRayLeather,3223537152,Textiles,Belalans Ray Leather
+128667062,DamnaCarapaces,3227751936,Textiles,Damna Carapaces
+128667063,RapaBaoSnakeSkins,3222875648,Textiles,Rapa Bao Snake Skins
+128667064,VanayequiRhinoFur,3227289856,Textiles,Vanayequi Ceratomorpha Fur
+128667065,BastSnakeGin,128086776,Legal Drugs,Bast Snake Gin
+128667066,ThrutisCream,3226522368,Legal Drugs,Thrutis Cream
+128667067,WulpaHyperboreSystems,3221388032,Machinery,Wulpa Hyperbore Systems
+128667068,AganippeRush,128012800,Medicines,Aganippe Rush
+128667069,TerraMaterBloodBores,128051466,Medicines,Terra Mater Blood Bores
+128667070,HolvaDuellingBlades,3222713088,Weapons,Holva Duelling Blades
+128667071,KamorinHistoricWeapons,3221669632,Weapons,Kamorin Historic Weapons
+128667072,GilyaSignatureWeapons,3226857216,Weapons,Gilya Signature Weapons
+128667073,DeltaPhoenicisPalms,128045312,Chemicals,Delta Phoenicis Palms
+128667074,ToxandjiVirocide,3230258688,Chemicals,Toxandji Virocide
+128667075,XiheCompanions,3224133120,Technology,Xihe Biomorphic Companions
+128667076,SanumaMEAT,3230331136,Foods,Sanuma Decorative Meat
+128667077,EthgrezeTeaBuds,3229524992,Foods,Ethgreze Tea Buds
+128667078,CeremonialHeikeTea,3227417856,Foods,Ceremonial Heike Tea
+128667079,TanmarkTranquilTea,128057866,Foods,Tanmark Tranquil Tea
+128667080,AZCancriFormula42,3228400128,Technology,AZ Cancri Formula 42
+128667081,KamitraCigars,3225450752,Legal Drugs,Kamitra Cigars
+128667082,RusaniOldSmokey,3229255680,Legal Drugs,Rusani Old Smokey
+128667083,YasoKondiLeaf,3223088640,Legal Drugs,Yaso Kondi Leaf
+128667084,ChateauDeAegaeon,3228416768,Legal Drugs,Chateau De Aegaeon
+128667085,WatersOfShintara,128666762,Medicines,The Waters of Shintara
+128667668,OphiuchiExinoArtefacts,3228939264,Consumer Items,Ophiuch Exino Artefacts
+128667669,BakedGreebles,3229378560,Foods,Baked Greebles
+128667670,CetiAepyornisEgg,3222560256,Foods,Aepyornis Egg
+128667671,SaxonWine,3227986432,Legal Drugs,Saxon Wine
+128667672,CentauriMegaGin,3228728832,Legal Drugs,Centauri Mega Gin
+128667673,AnduligaFireWorks,3230243584,Consumer Items,Anduliga Fire Works
+128667674,BankiAmphibiousLeather,3228346112,Textiles,Banki Amphibious Leather
+128667675,CherbonesBloodCrystals,3229594624,Metals,Cherbones Blood Crystals
+128667676,MotronaExperienceJelly,3229750528,Legal Drugs,Motrona Experience Jelly
+128667677,GeawenDanceDust,3230954752,Legal Drugs,Geawen Dance Dust
+128667678,GerasianGueuzeBeer,3228047360,Legal Drugs,Gerasian Gueuze Beer
+128667679,HaidneBlackBrew,3226557696,Foods,Haiden Black Brew
+128667680,HavasupaiDreamCatcher,3221438976,Consumer Items,Havasupai Dream Catcher
+128667681,BurnhamBileDistillate,3230224384,Legal Drugs,Burnham Bile Distillate
+128667682,HIPOrganophosphates,3227036160,Chemicals,HIP Organophosphates
+128667683,JaradharrePuzzlebox,3230754816,Consumer Items,Jaradharre Puzzle Box
+128667684,KorroKungPellets,3228726272,Chemicals,Koro Kung Pellets
+128667685,LFTVoidExtractCoffee,3229028864,Foods,Void Extract Coffee
+128667686,HonestyPills,3229561344,Medicines,Honesty Pills
+128667687,NonEuclidianExotanks,3224135424,Machinery,Non Euclidian Exotanks
+128667688,LTTHyperSweet,3224166400,Foods,LTT Hyper Sweet
+128667689,MechucosHighTea,3228398848,Foods,Mechucos High Tea
+128667690,MedbStarlube,3228762368,Chemicals,Medb Starlube
+128667691,MokojingBeastFeast,3229612800,Foods,Mokojing Beast Feast
+128667692,MukusubiiChitinOs,3221719296,Foods,Mukusubii Chitin-os
+128667693,MulachiGiantFungus,3228892672,Foods,Mulachi Giant Fungus
+128667694,NgadandariFireOpals,3226127872,Metals,Ngadandari Fire Opals
+128667695,TiegfriesSynthSilk,3227726848,Textiles,Tiegfries Synth Silk
+128667696,UzumokuLowGWings,3226474496,Consumer Items,Uzumoku Low-G Wings
+128667697,VHerculisBodyRub,3228959232,Medicines,V Herculis Body Rub
+128667698,WheemeteWheatCakes,3225032704,Foods,Wheemete Wheat Cakes
+128667699,VegaSlimWeed,128149240,Medicines,Vega Slimweed
+128667700,AltairianSkin,128151032,Consumer Items,Altairian Skin
+128667701,PavonisEarGrubs,128117240,Legal Drugs,Pavonis Ear Grubs
+128667702,JotunMookah,128078840,Textiles,Jotun Mookah
+128667703,GiantVerrix,128121336,Machinery,Giant Verrix
+128667704,IndiBourbon,128118520,Legal Drugs,Indi Bourbon
+128667705,AroucaConventualSweets,128098040,Foods,Arouca Conventual Sweets
+128667706,TauriChimes,128134648,Consumer Items,Tauri Chimes
+128667707,ZeesszeAntGlue,128125432,Consumer Items,Zeessze Ant Grub Glue
+128667708,PantaaPrayerSticks,3228824064,Medicines,Pantaa Prayer Sticks
+128667709,FujinTea,128134392,Foods,Fujin Tea
+128667710,ChameleonCloth,3223418880,Textiles,Chameleon Cloth
+128667711,OrrerianViciousBrew,128166392,Foods,Orrerian Vicious Brew
+128667712,UszaianTreeGrub,128164856,Foods,Uszaian Tree Grub
+128667713,MomusBogSpaniel,128075256,Consumer Items,Momus Bog Spaniel
+128667714,DisoMaCorn,128161016,Foods,Diso Ma Corn
+128667715,LeestianEvilJuice,128639992,Legal Drugs,Leestian Evil Juice
+128667716,BlueMilk,128639992,Foods,Azure Milk
+128667717,AlienEggs,128164088,Consumer Items,Leathery Eggs
+128667718,AlyaBodilySoap,3221638400,Medicines,Alya Body Soap
+128667719,VidavantianLace,3231082240,Consumer Items,Vidavantian Lace
+128667760,TransgenicOnionHead,128057866,Legal Drugs,Lucan Onionhead
+128668017,JaquesQuinentianStill,128667761,Consumer Items,Jaques Quinentian Still
+128668018,SoontillRelics,3225348096,Consumer Items,Soontill Relics
+128671119,Advert1,3227172352,Consumer Items,Ultra-Compact Processor Prototypes
+128672121,TheHuttonMug,3228728832,Consumer Items,The Hutton Mug
+128672122,SothisCrystallineGold,128668557,Metals,Sothis Crystalline Gold
+128672316,MasterChefs,128123640,Slavery,Master Chefs
+128672431,PersonalGifts,128081912,Salvage,Festive Gifts
+128672432,CrystallineSpheres,128059402,Salvage,Crystalline Spheres
+128672812,OnionHeadA,3226977024,Legal Drugs,Onionhead Alpha Strain
+128673069,OnionHeadB,3223027200,Legal Drugs,Onionhead Beta Strain
+128682050,GalacticTravelGuide,128673074,Salvage,Galactic Travel Guide
+128727921,AnimalEffigies,3228463360,Legal Drugs,Crom Silver Fesh
+128732551,ShansCharisOrchid,128107768,Consumer Items,Shan's Charis Orchid
+128748428,BuckyballBeerMats,128745551,Consumer Items,Buckyball Beer Mats
+128793113,HarmaSilverSeaRum,3221575424,Legal Drugs,Harma Silver Sea Rum
+128793114,PlatinumAloy,3223779840,Metals,Platinum Alloy
+128913661,Nanomedicines,3226651904,Medicines,Nanomedicines
+128922524,Duradrives,3223453184,Consumer Items,Duradrives
+128958679,ApaVietii,128958681,Legal Drugs,Apa Vietii
+129002574,ClassifiedExperimentalEquipment,128986325,Technology,Classified Experimental Equipment


### PR DESCRIPTION
Tested this by overwriting the `commodity.csv` file in an installed instance of BGS-Tally with the updated file bellow. This should address issue #300. While I learn a bit more about how BGS- Tally works, I am curious why we have our own version of this file rather than using the version EDMC has. Is that not accessible to plugins?