### PR TITLE
Fix objective overlay group defaults

### DIFF
--- a/bgstally/overlay.py
+++ b/bgstally/overlay.py
@@ -266,7 +266,6 @@ class Overlay:
             if anchor in ["ne", "right", "se"]:
                 # Assume a right side anchor means we're on the right side of the screen and force a small offset to avoid clipping.
                 id_prefix_offset_x = -5
-                justification = "right" # this does not work well with vector images.
             else:
                 id_prefix_offset_x = None
 

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -99,6 +99,7 @@ w = 320
 h = 25
 ttl = 30
 text_size = normal
+anchor = ne
 
 [overlay.frame.system_info]
 border_colour = None

--- a/config/userconfig.template.ini
+++ b/config/userconfig.template.ini
@@ -119,6 +119,7 @@ w = 320
 h = 25
 ttl = 30
 text_size = normal
+anchor = ne
 
 [overlay.frame.system_info]
 border_colour = None


### PR DESCRIPTION
`overlay.frame.objectives` has a negative X value. This means placement is on the right side of the screen. Anchor was not set so EDMCModernOverlay was placing the anchor at x=1280 (right edge of screen) and drawing the payload off screen. 

Added `anchor = ne` to `overlay.frame.objectives` and removed the forced justification for eastern most anchor in `overlay.py` so that it defaults to left if the overlay frame does not have justification defined. Validated visually using a test payload.

<img width="645" height="454" alt="image" src="https://github.com/user-attachments/assets/596b0b15-8f1a-4c58-ab29-6bb71541c255" />

For https://github.com/aussig/BGS-Tally/issues/429

**Release Notes**
CMDRs with `userconfig.template.ini` will either need to manually add `anchor = ne` to `[overlay.frame.objectives]` or use the EDMCModernOverlay [Overlay Controller](https://github.com/SweetJonnySauce/EDMCModernOverlay/wiki/Overlay-Controller) to set the anchor to "ne"