### PR TITLE
added justification and anchor to userconfig.template.ini

### DIFF
--- a/config/userconfig.template.ini
+++ b/config/userconfig.template.ini
@@ -145,6 +145,8 @@ w = 100
 h = 25
 ttl = 3
 text_size = large
+justification = right
+anchor = ne
 
 [overlay.frame.system_tick]
 border_colour = None
@@ -157,6 +159,8 @@ w = 100
 h = 25
 ttl = 3
 text_size = large
+justification = right
+anchor = ne
 
 [overlay.frame.tickwarn]
 border_colour = None
@@ -169,6 +173,8 @@ w = 100
 h = 25
 ttl = 1
 text_size = normal
+justification = right
+anchor = ne
 
 [overlay.frame.tw]
 border_colour = #1a4f09


### PR DESCRIPTION
`justification = right` and `anchor = ne` were added to overlay frames tick, system_tick, and tickwarn in `config.template.ini` when the change was made to use EDMCModernOverlay. 

These were not mirrored into `userconfig.template.ini`. This doesn't create a problem unless a user copies `userconfig.template.ini` to `userconfig.ini`. The visual impact is that tick, system_tick, and tickwarn appeared mostly offscreen (unless the EDMCModernOverlay nudge setting was set to true). 

This PR adds those configs to tick, system_tick, and tickwarn. This was purposely skipped in https://github.com/aussig/BGS-Tally/pull/432 but I was thinking users would use `userconfig.template.ini` and not copy them to `userconfig.ini`

**Note:** we did take `justification = right` out of `overlay.py`  in https://github.com/aussig/BGS-Tally/pull/432. But this config is still valid. The code we took out was forcing justification for right-most anchored plugin groups. [This setting is still respected if set](https://github.com/aussig/BGS-Tally/blob/bea4cbc5e6f8507f45d205549f05f58ac341bca2/bgstally/overlay.py#L253).