### PR TITLE
Fix(carrier-overlay): improve landing pad lockdown localization context and consistency

### DIFF
--- a/L10n/en.template.strings
+++ b/L10n/en.template.strings
@@ -1015,7 +1015,7 @@ completed";
 "Landing Pad Lockdown in" = "Landing Pad Lockdown in";
 
 /* fleetcarrier.py: Carrier overlay, notification indicating that landing pad lockdown is currently active; In files: fleetcarrier.py:392:392 */
-"Landing Pads Locked-down" = "Landing Pads Locked-down";
+"Landing Pads Locked down" = "Landing Pads Locked down";
 
 /* ui.py: Preferences label; In files: ui.py:252:252 */
 "Language for Discord Posts" = "Language for Discord Posts";

--- a/L10n/en.template.strings
+++ b/L10n/en.template.strings
@@ -1011,11 +1011,11 @@ completed";
 /* colonisation.py: Landable label; ravencolonial.py: Landable body feature label; In files: ravencolonial.py:898:898; colonisation.py:1870:1870 */
 "Landable" = "Landable";
 
-/* fleetcarrier.py: Carrier overlay; In files: fleetcarrier.py:388:388 */
+/* fleetcarrier.py: Carrier overlay, label followed by a countdown indicating time remaining until landing pad lockdown; In files: fleetcarrier.py:394:394 */
 "Landing Pad Lockdown in" = "Landing Pad Lockdown in";
 
-/* fleetcarrier.py: Carrier overlay; In files: fleetcarrier.py:386:386 */
-"Landing Pads Locked down" = "Landing Pads Locked down";
+/* fleetcarrier.py: Carrier overlay, notification indicating that landing pad lockdown is currently active; In files: fleetcarrier.py:392:392 */
+"Landing Pads Locked-down" = "Landing Pads Locked-down";
 
 /* ui.py: Preferences label; In files: ui.py:252:252 */
 "Language for Discord Posts" = "Language for Discord Posts";

--- a/bgstally/fleetcarrier.py
+++ b/bgstally/fleetcarrier.py
@@ -389,9 +389,9 @@ class FleetCarrier:
         if self.jump_state == FleetCarrierJump.Jumping and delta > 0:
             message = f"{_('Departure To')} {self.overview.get('jumpBody', self.overview.get('jumpDestination', 'Unknown'))} {_('in')} {cd}"  # LANG: Carrier overlay
             if delta < 200:
-                message += f"\n{_('Landing Pads Locked down')}" # LANG: Carrier overlay
+                message += f"\n{_('Landing Pads Locked-down')}" # LANG: Carrier overlay, notification indicating that landing pad lockdown is currently active
             if 200 <= delta < 600:
-                message += f"\n{_('Landing Pad Lockdown in')} {self._td_str(delta - 200)}" # LANG: Carrier overlay
+                message += f"\n{_('Landing Pad Lockdown in')} {self._td_str(delta - 200)}" # LANG: Carrier overlay, label followed by a countdown indicating time remaining until landing pad lockdown
             # Jump locked in 10 m before departure
             if 600 <= delta:
                 message += f"\n{_('Jump Initiation in')} {self._td_str(delta - 600)}" # LANG: Carrier overlay

--- a/bgstally/fleetcarrier.py
+++ b/bgstally/fleetcarrier.py
@@ -389,7 +389,7 @@ class FleetCarrier:
         if self.jump_state == FleetCarrierJump.Jumping and delta > 0:
             message = f"{_('Departure To')} {self.overview.get('jumpBody', self.overview.get('jumpDestination', 'Unknown'))} {_('in')} {cd}"  # LANG: Carrier overlay
             if delta < 200:
-                message += f"\n{_('Landing Pads Locked-down')}" # LANG: Carrier overlay, notification indicating that landing pad lockdown is currently active
+                message += f"\n{_('Landing Pads Locked down')}" # LANG: Carrier overlay, notification indicating that landing pad lockdown is currently active
             if 200 <= delta < 600:
                 message += f"\n{_('Landing Pad Lockdown in')} {self._td_str(delta - 200)}" # LANG: Carrier overlay, label followed by a countdown indicating time remaining until landing pad lockdown
             # Jump locked in 10 m before departure


### PR DESCRIPTION
## Fix: Improve localization context for landing pad lockdown messages

This PR improves the clarity of localization metadata for landing pad lockdown messages in the carrier overlay and standardizes wording for consistency.

### Changes

- Added explicit localization context for **"Locked-down"** state to indicate it represents an active landing pad lockdown condition.
- Added explicit localization context for **"Lockdown in"** to clarify it represents a countdown until the lockdown begins.
- ~~Standardized UI wording to use the **"locked-down"** form for consistency across the overlay.~~
- Updated language template comments to reflect the improved context for both strings.

### Diff summary

- ~~`Landing Pads Locked down` → `Landing Pads Locked-down`~~
- Improved LANG comments for:
  - Active lockdown status message
  - Countdown until lockdown begins

No functional changes to logic; UI behavior remains unchanged.