### PR TITLE
Changed to append so the overlay doesn't line-wrap every letter in the title. …

### DIFF
--- a/bgstally/overlay.py
+++ b/bgstally/overlay.py
@@ -75,7 +75,7 @@ class Overlay:
 
             # Put the title first
             if title != None and title != '':
-                segments += f"{TAG_OVERLAY_HIGHLIGHT}{title}"
+                segments.append(f"{TAG_OVERLAY_HIGHLIGHT}{title}")
             for line in lines:
                 segments += textwrap.wrap(line, width = 80, subsequent_indent = '  ')
 


### PR DESCRIPTION
…Fixes #494

Changed 
`segments += f"{TAG_OVERLAY_HIGHLIGHT}{title}"`
to
`segments.append(f"{TAG_OVERLAY_HIGHLIGHT}{title}")`

Verified no other `display_message` call uses `title`

Verified no regression in `system_info`. Did not check others.